### PR TITLE
add column 9 vits

### DIFF
--- a/src/cpp_modules/src/move_result.cpp
+++ b/src/cpp_modules/src/move_result.cpp
@@ -76,6 +76,15 @@ float analyzeHole(unsigned int board[20], int r, int c, int excludeHolesColumn, 
       board[r] |= TUCK_SETUP_BIT(c);
       return 0.65f; // Right side tuck, with minimal space = 1-piece solve + spin option.
     }
+    if (c <= 8
+        && r <= 16
+        && (board[r] & 0b11) == 0
+        && (board[r+1] & 0b11) == 0
+        && (board[r+2] & 0b11) == 0
+        && (board[r+3] & 0b11) == 0){
+      board[r] |= TUCK_SETUP_BIT(c);
+      return 0.65f; // literally just a vits = 1-piece solve
+    }
   }
   if (c == excludeHolesColumn) {
     if ((board[r] & ALL_HOLE_BITS) == 0){

--- a/src/cpp_modules/src/move_result.cpp
+++ b/src/cpp_modules/src/move_result.cpp
@@ -83,6 +83,9 @@ float analyzeHole(unsigned int board[20], int r, int c, int excludeHolesColumn, 
         && (board[r+2] & 0b11) == 0
         && (board[r+3] & 0b11) == 0){
       board[r] |= TUCK_SETUP_BIT(c);
+      board[r+1] |= TUCK_SETUP_BIT(c);
+      board[r+2] |= TUCK_SETUP_BIT(c);
+      board[r+3] |= TUCK_SETUP_BIT(c);
       return 0.65f; // column 9 vits = 1-piece solve
     }
   }

--- a/src/cpp_modules/src/move_result.cpp
+++ b/src/cpp_modules/src/move_result.cpp
@@ -86,7 +86,7 @@ float analyzeHole(unsigned int board[20], int r, int c, int excludeHolesColumn, 
       board[r+1] |= TUCK_SETUP_BIT(c);
       board[r+2] |= TUCK_SETUP_BIT(c);
       board[r+3] |= TUCK_SETUP_BIT(c);
-      return 0.65f; // column 9 vits = 1-piece solve
+      return 0.8f; // column 9 vits = 1-piece solve
     }
   }
   if (c == excludeHolesColumn) {

--- a/src/cpp_modules/src/move_result.cpp
+++ b/src/cpp_modules/src/move_result.cpp
@@ -76,14 +76,14 @@ float analyzeHole(unsigned int board[20], int r, int c, int excludeHolesColumn, 
       board[r] |= TUCK_SETUP_BIT(c);
       return 0.65f; // Right side tuck, with minimal space = 1-piece solve + spin option.
     }
-    if (c <= 8
+    if (c == 8
         && r <= 16
         && (board[r] & 0b11) == 0
         && (board[r+1] & 0b11) == 0
         && (board[r+2] & 0b11) == 0
         && (board[r+3] & 0b11) == 0){
       board[r] |= TUCK_SETUP_BIT(c);
-      return 0.65f; // literally just a vits = 1-piece solve
+      return 0.65f; // column 9 vits = 1-piece solve
     }
   }
   if (c == excludeHolesColumn) {


### PR DESCRIPTION
The lack of column 9 vits vision has been a notorious pain point for nestris.org puzzle enjoyers. Every other day Ansel gets someone asking him to add this and tbh this pissed me off a lot. So much so that it inspired me (who is neither you nor Ansel), to add this, and here we are.

Change is simple so hopefully this is easy to review/fine-tune. I tested the move search on some sample boards and got good-looking results, but I haven't done anything more end-to-end (among other things, idk if 0.65 is a good weight).

One more thing: your last stackrabbit update broke puzzles, so we might want to coordinate with him if/when you merge this in/redeploy.