### PR TITLE
Update nan to support Node.js 22+

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@types/express": "^4.17.12",
     "dotenv": "^16.3.1",
     "fs": "0.0.1-security",
-    "nan": "^2.14.2",
+    "nan": "^2.27.0",
     "node-fetch": "^2.6.1",
     "prettier": "^2.0.5"
   }


### PR DESCRIPTION
The current nan@^2.14.2 fails to compile with Node.js 22+ due to breaking V8 API changes in newer versions. Updated to nan@^2.27.0 which supports both older and newer Node.js releases.

Without this change, npm start (which runs node-gyp build) fails with compilation errors on Node.js 22.